### PR TITLE
Fix Use Case capsule CORS + site content updates

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import Partners from './pages/Partners';
 import FAQ from './pages/FAQ';
 import Terms from './pages/Terms';
 import Privacy from './pages/Privacy';
+import UseCase from './pages/UseCase';
 import NotFound from './pages/NotFound';
 
 const queryClient = new QueryClient();
@@ -33,6 +34,8 @@ const App = () => (
               <Route path="/faq" element={<FAQ />} />
               <Route path="/terms" element={<Terms />} />
               <Route path="/privacy" element={<Privacy />} />
+              <Route path="/use-case" element={<UseCase />} />
+              <Route path="/usecase" element={<UseCase />} />
               {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
               <Route path="*" element={<NotFound />} />
             </Routes>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -13,7 +13,7 @@ const Navigation = () => {
   const location = useLocation();
 
   const navItems = [
-    { name: 'Usecase', href: '/use-case', forceReload: true },
+    { name: 'Usecase', href: '/use-case' },
     { name: 'Partners', href: '/partners' },
     { name: 'Sponsors', href: '/sponsors' },
     { name: 'FAQ', href: '/faq' },

--- a/src/config/links.ts
+++ b/src/config/links.ts
@@ -1,2 +1,7 @@
 export const NEWSLETTER_URL = 'https://mailchi.mp/704e7264267c/relay-funder-newsletter';
 
+// Capsules-hosted "Use Case" story, embedded via iframe so it loads under the
+// app.capsules.ink origin (its data fetch to assets.capsules.ink is only
+// CORS-allowed there — proxying it onto relayfunder.com breaks with a CORS error).
+export const USE_CASE_CAPSULE_URL = 'https://app.capsules.ink/sara/relay-funder';
+

--- a/src/pages/UseCase.tsx
+++ b/src/pages/UseCase.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import { USE_CASE_CAPSULE_URL } from '@/config/links';
+import { trackPageView } from '@/lib/analytics';
+
+const UseCase = () => {
+  useEffect(() => {
+    trackPageView('Use Case');
+  }, []);
+
+  return (
+    <iframe
+      src={USE_CASE_CAPSULE_URL}
+      title="Relay Funder — Use Case"
+      className="fixed inset-0 h-full w-full border-0"
+      allow="fullscreen; clipboard-write"
+    />
+  );
+};
+
+export default UseCase;

--- a/vercel.json
+++ b/vercel.json
@@ -1,15 +1,7 @@
 {
   "rewrites": [
     {
-      "source": "/use-case",
-      "destination": "https://app.capsules.ink/sara/relay-funder"
-    },
-    {
-      "source": "/usecase",
-      "destination": "https://app.capsules.ink/sara/relay-funder"
-    },
-    {
-      "source": "/((?!api/|use-case|usecase).*)",
+      "source": "/((?!api/).*)",
       "destination": "/index.html"
     }
   ]


### PR DESCRIPTION
## Summary

Brings `sara-updates` up to date on `main`. The headline fix is the **Use Case page**, plus several content/config updates.

### Fix: Use Case capsule no longer breaks with a CORS error
`relayfunder.com/use-case` was showing **"Failed to load capsule data."** The `vercel.json` rewrites reverse-proxied the Capsules page onto the `relayfunder.com` origin; the capsule's JS then fetched its data from `assets.capsules.ink` cross-origin, which Capsules only CORS-allows for the `app.capsules.ink` origin → blocked.

Now the page embeds the capsule via an **iframe** to `app.capsules.ink/sara/relay-funder`, so it loads under its own origin where the data fetch is allowed.

- Removed the two `capsules.ink` proxy rewrites; kept a standard SPA fallback in `vercel.json`
- Added `src/pages/UseCase.tsx` (full-viewport iframe) and routed `/use-case` + `/usecase` to it
- Made the "Usecase" nav link a normal SPA link (dropped `forceReload`)
- Centralized the capsule URL in `src/config/links.ts`

### Other changes in this branch
- Update hero round status to completed; remove "shared" from match-fund copy
- Update partner logos / data; remove featured Refunite card; simplify Partners page
- Add Telegram link to footer
- Add local Vite config + package metadata; remove platform-specific SWC deps

## Test plan
- `vite build` and `tsc --noEmit` pass clean
- Local dev: `/use-case` serves and mounts; capsule URL is bundled into the production JS
- After deploy: confirm `relayfunder.com/use-case` renders the capsule with no CORS error in the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Use Case page accessible via the app's navigation.

* **Improvements**
  * Updated Use Case navigation to use internal routing for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->